### PR TITLE
Fix Align of Zero Infinity

### DIFF
--- a/tools/Malie/database_malie.py
+++ b/tools/Malie/database_malie.py
@@ -1781,7 +1781,7 @@ database_malie = {
       1698185779,
       1634498932
     ],
-    "Align": 4096
+    "Align": 1024
   },
   "Zettai Meikyuu Grimm": {
     "Key": [


### PR DESCRIPTION
GARbro extracts broken files, so I tried with exdieslib_v2 and the Align turns out to be 1024